### PR TITLE
chore: remove commitizen from our dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,6 @@
   "bugs": {
     "url": "https://github.com/semantic-release/changelog/issues"
   },
-  "config": {
-    "commitizen": {
-      "path": "cz-conventional-changelog"
-    }
-  },
   "contributors": [
     "Stephan Bönnemann <stephan@boennemann.me> (http://boennemann.me)",
     "Gregor Martynus (https://twitter.com/gr2m)"
@@ -25,8 +20,6 @@
     "ava": "^2.0.0",
     "clear-module": "^3.0.0",
     "codecov": "^3.0.0",
-    "commitizen": "^4.0.0",
-    "cz-conventional-changelog": "^2.0.0",
     "nyc": "^14.0.0",
     "semantic-release": "^15.0.0",
     "sinon": "^7.1.1",
@@ -78,7 +71,6 @@
     "url": "https://github.com/semantic-release/changelog.git"
   },
   "scripts": {
-    "cm": "git-cz",
     "codecov": "codecov -f coverage/coverage-final.json",
     "lint": "xo",
     "pretest": "npm run lint",


### PR DESCRIPTION
Less dependencies to maintain.
Users who want to use Commitizen can use their own local install.