### PR TITLE
fix: use correct peerDependencies for semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "all": true
   },
   "peerDependencies": {
-    "semantic-release": ">=15.8.0 <16.0.0"
+    "semantic-release": ">=15.8.0 <16.0.0 || >=16.0.0-beta <17.0.0"
   },
   "prettier": {
     "printWidth": 120,


### PR DESCRIPTION
```
##[error]npm WARN @semantic-release/changelog@3.0.5 requires a peer of semantic-release@>=15.8.0 <16.0.0 but none is installed.
```