### PR TITLE
chore: update npm badge from `next` to `beta` version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > Please consider whether committing release notes to a file is worth the [added complexity](https://semantic-release.gitbook.io/semantic-release/support/faq#should-release-notes-be-committed-to-a-changelog.md-in-my-repository-during-a-release) compared to other available options for capturing release notes.
 
 [![Build Status](https://github.com/semantic-release/changelog/workflows/Test/badge.svg)](https://github.com/semantic-release/changelog/actions?query=workflow%3ATest+branch%3Amaster) [![npm latest version](https://img.shields.io/npm/v/@semantic-release/changelog/latest.svg)](https://www.npmjs.com/package/@semantic-release/changelog)
-[![npm next version](https://img.shields.io/npm/v/@semantic-release/changelog/next.svg)](https://www.npmjs.com/package/@semantic-release/changelog)
+[![npm beta version](https://img.shields.io/npm/v/@semantic-release/changelog/beta.svg)](https://www.npmjs.com/package/@semantic-release/changelog)
 
 | Step               | Description                                                                                                                                                                                           |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
This pull request updates the badge in the `README.md` to display the beta version of the package instead of the next version.

- Documentation update:
  * Changed the npm badge to show the beta version (`@semantic-release/changelog/beta`) instead of the next version (`@semantic-release/changelog/next`).